### PR TITLE
Shout out cooldowns and moderation logs error logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sushi-bot",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sushi-bot",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sushi-bot",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Sushi Bot, a Discord bot for VTubers, built with TypeScript and discord.js",
     "main": "dist/index.js",
     "scripts": {

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -395,9 +395,10 @@ export const onPresenceUpdate = async (client: Client, before: Presence, after: 
         }
     }
 
-    // If a stream has ended, add a cooldown
+    // If a stream has ended, add a cooldown and skip
     if (oldStreams.length > streams.length) {
         startCooldown(uid);
+        return;
     }
 
     // Skip if the member is on cooldown or no stream was found

--- a/src/events/shoutout.ts
+++ b/src/events/shoutout.ts
@@ -22,11 +22,13 @@
  * SOFTWARE.
  */
 
-import { Activity } from "discord.js";
+import { Activity, Snowflake } from "discord.js";
 
 /*
  * This module has a string formatter for auto shout outs and go-live posts
  */
+
+// ----- STRING FORMATTING -----
 
 /**
  * The string that gets replaced with the streamer's Discord display name
@@ -85,6 +87,7 @@ const getTwitchUsername = (link: string): string | null => {
     // Twitch stream links are formatted https://twitch.tv/{username}
     const tokens: string[] = link.split("/");
     // Return {username}
+    // eslint-disable-next-line no-magic-numbers
     return tokens[tokens.length - 1];
 };
 
@@ -111,3 +114,56 @@ export const formatGoLivePost = (activity: Activity, template: string): string |
         .replace(GAME_RE, game)
         .replace(NEW_LINE_RE, "\n");
 };
+
+// ----- !STRING FORMATTING -----
+
+
+// ----- COOLDOWNS -----
+
+/**
+ * The cooldown period in milliseconds.
+ */
+const TEN_MINUTES: number = 600_000;
+
+/**
+ * The cached shout out cooldowns.
+ */
+const cooldownCache: Map<Snowflake, NodeJS.Timeout> = new Map();
+
+/**
+ * Starts a cooldown for a user.
+ * Users on cooldown will not be shouted out.
+ * 
+ * @param user the ID of the user to start a cooldown for
+ */
+export const startCooldown = (user: Snowflake): void => {
+    // Get the existing cooldown if there is one
+    const cooldown: NodeJS.Timeout = cooldownCache.get(user);
+
+    // Remove the cooldown if it exists
+    if (cooldown) {
+        clearTimeout(cooldown);
+    }
+
+    // Set a new cooldown
+    cooldownCache.set(
+        user,
+        setTimeout(() => {
+            cooldownCache.delete(user);
+        }, TEN_MINUTES)
+    );
+};
+
+/**
+ * Checks whether a user is on cooldown or not.
+ * 
+ * @param user the ID of the user to check
+ */
+export const onCooldown = (user: Snowflake): boolean => {
+    // Get the existing cooldown if there is one
+    const cooldown: NodeJS.Timeout = cooldownCache.get(user);
+
+    return cooldown ? true : false;
+};
+
+// ----- COOLDOWNS -----

--- a/src/util/error-handler.ts
+++ b/src/util/error-handler.ts
@@ -254,7 +254,7 @@ export const moderationLogsErrorHandler = async <T extends LogsAction>(
 
             before = "user: {\n" +
                      `\tusername: ${beforeUser.username}\n` +
-                     `\tisplay name: ${beforeUser.displayName}\n` +
+                     `\tdisplay name: ${beforeUser.displayName}\n` +
                      `\tavatar: ${beforeUser.avatarURL()}\n` +
                      "}";
             after = "user: {\n" +

--- a/src/util/error-handler.ts
+++ b/src/util/error-handler.ts
@@ -186,17 +186,6 @@ type LogsAction = MemberLogsAction |
     MessageLogsAction;
 
 /**
- * The trigger of a logs error.
- * A User if it's related to a user update, or a ban, or
- * a message.
- * otherwise a member.
- */
-type Trigger<T extends LogsAction> = T extends ProfileLogsAction.UserUpdate |
-    MemberLogsAction.MemberBan |
-    MemberLogsAction.MemberUnban |
-    MessageLogsAction ? User : GuildMember;
-
-/**
  * The payload of a logs error.
  * The before and after states of a Message if it's a message edit action, or
  * a single message if it's a message delete action, or
@@ -222,14 +211,11 @@ type Payload<T extends LogsAction> = T extends MessageLogsAction.MessageEdit ? [
 export const moderationLogsErrorHandler = async <T extends LogsAction>(
     action: T,
     server: Guild,
-    trigger: Trigger<T>,
+    trigger: User,
     err: Error,
     ...payload: Payload<T>
 ): Promise<void> => {
     console.log(err);
-    
-    const username: string = trigger instanceof User ? trigger.username : trigger.user.username;
-    const uid: string = trigger instanceof User ? trigger.username : trigger.user.username;
 
     // The states from the payload
     let before: string = null;
@@ -284,7 +270,7 @@ export const moderationLogsErrorHandler = async <T extends LogsAction>(
     const report: string = "```\n" +
                            `${action} Error\n\n` +
                            `Server: ${server?.name}\n` +
-                           `Trigger: ${uid} (${username})\n\n` +
+                           `Trigger: ${trigger.id} (${trigger.username})\n\n` +
                            `${before ? "Payload\n\n" : ""}` +
                            `${before ? before + "\n": "" }${after ? after + "\n" : ""}` +
                            `${before ? "\n" : ""}` +

--- a/src/util/error-handler.ts
+++ b/src/util/error-handler.ts
@@ -23,8 +23,8 @@
  */
 
 import {
-    ButtonInteraction, ChatInputCommandInteraction, DiscordAPIError, Interaction,
-    InteractionReplyOptions, User
+    ButtonInteraction, ChatInputCommandInteraction, DiscordAPIError, Guild, GuildMember,
+    Interaction, InteractionReplyOptions, Message, User
 } from "discord.js";
 import { NoMemberFoundError, UserIsMemberError } from "./errors";
 import { getAdminLogsChannel } from "./channels";
@@ -150,4 +150,147 @@ export const reactionRolesErrorHandler: ErrorHandler = async (ctx: ButtonInterac
     await getAdminLogsChannel().send(report);
     
     // ----- !ERROR LOG -----
+};
+
+/**
+ * Actions related to the members logs category.
+ */
+export enum MemberLogsAction {
+    MemberJoin = "Member Join",
+    MemberLeave = "Member Leave",
+    MemberBan = "Member Ban",
+    MemberUnban = "Member Unban"
+}
+
+/**
+ * Actions related to the profiles logs category.
+ */
+export enum ProfileLogsAction {
+    MemberUpdate = "Member Update",
+    UserUpdate = "User Update"
+}
+
+/**
+ * Actions related to the messages logs category.
+ */
+export enum MessageLogsAction {
+    MessageEdit = "Message Edit",
+    MessageDelete = "Message Delete"
+}
+
+/**
+ * All logs categories.
+ */
+type LogsAction = MemberLogsAction |
+    ProfileLogsAction |
+    MessageLogsAction;
+
+/**
+ * The trigger of a logs error.
+ * A User if it's related to a user update, or a ban, or
+ * a message.
+ * otherwise a member.
+ */
+type Trigger<T extends LogsAction> = T extends ProfileLogsAction.UserUpdate |
+    MemberLogsAction.MemberBan |
+    MemberLogsAction.MemberUnban |
+    MessageLogsAction ? User : GuildMember;
+
+/**
+ * The payload of a logs error.
+ * The before and after states of a Message if it's a message edit action, or
+ * a single message if it's a message delete action, or
+ * the before and after states of a User if it's a user update action, or
+ * the before and after states of a Member if it's a member update action.
+ */
+type Payload<T extends LogsAction> = T extends MessageLogsAction.MessageEdit ? [before: Message, after: Message] :
+    T extends MessageLogsAction ? [message: Message] :
+    T extends ProfileLogsAction.UserUpdate ? [before: User, after: User] :
+    T extends ProfileLogsAction.MemberUpdate ? [before: GuildMember, after: GuildMember] :
+    [];
+
+/**
+ * Handles errors related to moderation logs.
+ * It logs the error along with any payload to the error logs channel.
+ * 
+ * @param action the logs action
+ * @param server the server the error originated from
+ * @param trigger the member or user who triggered the error
+ * @param err the error that occurred
+ * @param payload the error payload
+ */
+export const moderationLogsErrorHandler = async <T extends LogsAction>(
+    action: T,
+    server: Guild,
+    trigger: Trigger<T>,
+    err: Error,
+    ...payload: Payload<T>
+): Promise<void> => {
+    console.log(err);
+    
+    const username: string = trigger instanceof User ? trigger.username : trigger.user.username;
+    const uid: string = trigger instanceof User ? trigger.username : trigger.user.username;
+
+    // The states from the payload
+    let before: string = null;
+    let after: string = null;
+
+    /*eslint-disable no-magic-numbers*/
+    if (payload.length === 1) {
+        // Payload length of 1 means that a message was deleted
+        // We're slicing it to avoid having the error log message
+        // exceed the character limit
+        before = payload[0].content.slice(0, 100);
+    } else if (payload.length === 2) {
+        // Payload length of 2 means that something has changed
+        if (payload[0] instanceof Message) {
+            // If it's a message update, take the content of them
+            before = payload[0].content.slice(0, 100);
+            after = (<Message> payload[1]).content.slice(0, 100);
+        } else if (payload[0] instanceof User) {
+            // If it's a user profile update, take the relevant data
+            const beforeUser: User = payload[0];
+            const afterUser: User = <User> payload[1];
+
+            before = "user: {\n" +
+                     `\tusername: ${beforeUser.username}\n` +
+                     `\tisplay name: ${beforeUser.displayName}\n` +
+                     `\tavatar: ${beforeUser.avatarURL()}\n` +
+                     "}";
+            after = "user: {\n" +
+                    `\tusername: ${afterUser.username}\n` +
+                    `\tdisplay name: ${afterUser.displayName}\n` +
+                    `\tavatar: ${afterUser.avatarURL()}\n` +
+                    "}";
+        } else {
+            // Do the same for member profile updates
+            const beforeMember: GuildMember = payload[0];
+            const afterMember: GuildMember = <GuildMember> payload[1];
+
+            before = "member: {\n" +
+                     `\tusername: ${beforeMember.user.username}\n` +
+                     `\tnickname: ${beforeMember.nickname}\n` +
+                     `\tavatar: ${beforeMember.avatarURL()}\n` +
+                     "}";
+            after = "user: {\n" +
+                    `\tusername: ${afterMember.user.username}\n` +
+                    `\tnickname: ${afterMember.nickname}\n` +
+                    `\tavatar: ${afterMember.avatarURL()}\n` +
+                    "}";
+        }
+    }
+    /*eslint-enable no-magic-numbers*/
+
+    const report: string = "```\n" +
+                           `${action} Error\n\n` +
+                           `Server: ${server?.name}\n` +
+                           `Trigger: ${uid} (${username})\n\n` +
+                           `${before ? "Payload\n\n" : ""}` +
+                           `${before ? before + "\n": "" }${after ? after + "\n" : ""}` +
+                           `${before ? "\n" : ""}` +
+                           // Error name, and error code if it's a Discord API error
+                           `${err.name}${err instanceof DiscordAPIError ? `: ${err.code} (${err.message})` : ""}\n` +
+                           "```";
+    
+    await getAdminLogsChannel().send(report);
 };

--- a/src/util/init.ts
+++ b/src/util/init.ts
@@ -34,6 +34,7 @@ import {
     onMessageDelete, onMessageEdit, onPresenceUpdate, onServerJoin, onUserUpdate
 } from "../events/events";
 import { initRefreshReactionRolesInterval } from "../events/reactionroles";
+import { MemberLogsAction, MessageLogsAction, ProfileLogsAction, moderationLogsErrorHandler } from "./error-handler";
 
 /**
  * This module has an initialisation routine for the bot
@@ -92,35 +93,114 @@ export const loadListeners = (client: Client): void => {
     });
 
     client.on(Events.GuildMemberAdd, async (member: GuildMember): Promise<void> => {
-        await onMemberJoin(client, member);
+        try {
+            await onMemberJoin(client, member);
+        } catch (e) {
+            await moderationLogsErrorHandler(
+                MemberLogsAction.MemberJoin,
+                member.guild,
+                member,
+                e
+            );
+        }
     });
 
     client.on(Events.GuildMemberRemove, async (member: GuildMember): Promise<void> => {
-        await onMemberLeave(client, member);
+        try {
+            await onMemberLeave(client, member);
+        } catch (e) {
+            await moderationLogsErrorHandler(
+                MemberLogsAction.MemberLeave,
+                member.guild,
+                member,
+                e
+            );
+        }
     });
 
     client.on(Events.GuildBanAdd, async (ban: GuildBan): Promise<void> => {
-        await onMemberBan(client, ban);
+        try {
+            await onMemberBan(client, ban);
+        } catch (e) {
+            await moderationLogsErrorHandler(
+                MemberLogsAction.MemberBan,
+                ban.guild,
+                ban.user,
+                e
+            );
+        }
     });
 
     client.on(Events.GuildBanRemove, async (ban: GuildBan): Promise<void> => {
-        await onMemberUnban(client, ban);
+        try {
+            await onMemberUnban(client, ban);
+        } catch (e) {
+            await moderationLogsErrorHandler(
+                MemberLogsAction.MemberBan,
+                ban.guild,
+                ban.user,
+                e
+            );
+        }
     });
 
     client.on(Events.GuildMemberUpdate, async (before: GuildMember, after: GuildMember): Promise<void> => {
-        await onMemberUpdate(client, before, after);
+        try {
+            await onMemberUpdate(client, before, after);
+        } catch (e) {
+            await moderationLogsErrorHandler(
+                ProfileLogsAction.MemberUpdate,
+                before.guild,
+                before,
+                e,
+                before,
+                after
+            );
+        }
     });
 
     client.on(Events.UserUpdate, async (before: User, after: User): Promise<void> => {
-        await onUserUpdate(client, before, after);
+        try {
+            await onUserUpdate(client, before, after);
+        } catch (e) {
+            await moderationLogsErrorHandler(
+                ProfileLogsAction.UserUpdate,
+                null,
+                before,
+                e,
+                before,
+                after
+            );
+        }
     });
 
     client.on(Events.MessageUpdate, async (before: Message, after: Message): Promise<void> => {
-        await onMessageEdit(client, before, after);
+        try {
+            await onMessageEdit(client, before, after);
+        } catch (e) {
+            await moderationLogsErrorHandler(
+                MessageLogsAction.MessageEdit,
+                before.guild,
+                before.author,
+                e,
+                before,
+                after
+            );
+        }
     });
 
     client.on(Events.MessageDelete, async (message: Message): Promise<void> => {
-        await onMessageDelete(client, message);
+        try {
+            await onMessageDelete(client, message);
+        } catch (e) {
+            await moderationLogsErrorHandler(
+                MessageLogsAction.MessageDelete,
+                message.guild,
+                message.author,
+                e,
+                message
+            );
+        }
     });
 
     client.on(Events.Error, async (error: Error): Promise<void> => {

--- a/src/util/init.ts
+++ b/src/util/init.ts
@@ -99,7 +99,7 @@ export const loadListeners = (client: Client): void => {
             await moderationLogsErrorHandler(
                 MemberLogsAction.MemberJoin,
                 member.guild,
-                member,
+                member.user,
                 e
             );
         }
@@ -112,7 +112,7 @@ export const loadListeners = (client: Client): void => {
             await moderationLogsErrorHandler(
                 MemberLogsAction.MemberLeave,
                 member.guild,
-                member,
+                member.user,
                 e
             );
         }
@@ -151,7 +151,7 @@ export const loadListeners = (client: Client): void => {
             await moderationLogsErrorHandler(
                 ProfileLogsAction.MemberUpdate,
                 before.guild,
-                before,
+                before.user,
                 e,
                 before,
                 after


### PR DESCRIPTION
# What Does This PR Do?
This PR adds a cooldown to automatic shout outs- and go-live posts, and adds error logs for moderation logs.

## Acceptance Criteria Met
- Users are put on a 10 minute shout out/go-live cooldown when their stream goes offline.
- Users who are on a shout out/go-live cooldown will not trigger any shout outs/go-live posts.
- Moderation logs errors are handled by it own error handler.
- The moderation logs error handler outputs error logs to a designated error log channel in Sushi Hub.
- The error logs include:
  - the moderation log type,
  - the server the error occurred in,
  - the user who triggered it, and
  - a payload if applicable.

## Related Issues
Closes #38 
Closes #39 
