### PR TITLE
Fix uptime formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sushi-bot",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sushi-bot",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sushi-bot",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "Sushi Bot, a Discord bot for VTubers, built with TypeScript and discord.js",
     "main": "dist/index.js",
     "scripts": {

--- a/src/commands/miscellaneous/stats.ts
+++ b/src/commands/miscellaneous/stats.ts
@@ -82,7 +82,7 @@ const secsPerDay: number = 86400;
 const formatUptime = (uptime: number): string => {
     // Total seconds translated to hours, minutes, seconds
     const days: number = Math.floor(uptime / secsPerDay);
-    const hours: number = Math.floor(Math.floor(uptime % secsPerHour) / secsPerHour);
+    const hours: number = Math.floor(Math.floor(uptime % secsPerDay) / secsPerHour);
     const minutes: number = Math.floor(Math.floor(uptime % secsPerHour) / secsPerMin);
     const seconds: number = Math.floor(Math.floor(uptime % secsPerHour) % secsPerMin);
 


### PR DESCRIPTION
# Which Bug Does This PR Address?
This PR addresses a minor bug related to the uptime formatting in the `/stats` command, where the amount of hours would be ignored.
This PR does not require a review because the fix is so small, see the comment for the change.
