### PR TITLE
More action commands, view server configs, and mod log error logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sushi-bot",
-    "version": "2.0.2",
+    "version": "2.1.0-dev",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sushi-bot",
-            "version": "2.0.2",
+            "version": "2.1.0-dev",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sushi-bot",
-    "version": "2.1.0-dev",
+    "version": "2.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sushi-bot",
-            "version": "2.1.0-dev",
+            "version": "2.1.0",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sushi-bot",
-    "version": "2.1.0-dev",
+    "version": "2.1.0",
     "description": "Sushi Bot, a Discord bot for VTubers, built with TypeScript and discord.js",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sushi-bot",
-    "version": "2.0.2",
+    "version": "2.1.0-dev",
     "description": "Sushi Bot, a Discord bot for VTubers, built with TypeScript and discord.js",
     "main": "dist/index.js",
     "scripts": {

--- a/src/commands/action/bite.ts
+++ b/src/commands/action/bite.ts
@@ -1,0 +1,106 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023-present Zahatikoff, Mirage Aegis
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import {
+    ChatInputCommandInteraction, EmbedBuilder, GuildMember, SlashCommandBuilder
+} from "discord.js";
+import { Command } from "../../util/command-template.js";
+import { defaultErrorHandler } from "../../util/error-handler.js";
+import { TenorSingleton } from "../../util/tenor-utils.js";
+import { RED } from "../../util/colours.js";
+
+/*
+ * Creates an embed that states that the user had been bitten.
+ * The embed has an appropriate gif.
+ */
+
+const name: string = "bite";
+
+export const command: Command = {
+    // Command headers
+    data: <SlashCommandBuilder> new SlashCommandBuilder()
+        .setName(name)
+        .setDescription("Nom on someone!")
+        .setDMPermission(false)
+        .addUserOption(o =>
+            o.setName("target")
+                .setDescription("The user you want to bite")
+                .setRequired(true)
+        ),
+
+    // Command execution
+    async execute(ctx: ChatInputCommandInteraction): Promise<void> {
+        const tenor: TenorSingleton = TenorSingleton.getInstance();
+        const biter: GuildMember = <GuildMember> ctx.member;
+        const bit: GuildMember = <GuildMember> ctx.options.getMember("target") ?? null;
+        const gif: string = await tenor.getGifs("anime+bite");
+
+        // If the user provided wasn't a member,
+        // tell the user so
+        if (!bit) {
+            await ctx.reply("Couldn't find that member... who are you trying to bite?");
+            return;
+        }
+
+        let response: string;
+
+        switch (true) {
+            case biter.id === bit.id:
+                // User tries to bonk themselves
+                response = "Wait, why would you do that?\n" +
+                           `${biter} bites themselves!`;
+                break;
+            case bit.id === ctx.client.user.id:
+                // User tries to bonk Sushi Bot
+                response = "Hey! I'm not *actually* edible\n" +
+                           `${ctx.client.user} bites ${biter}!!!`;
+                break;
+            default:
+                // User bonks someone else
+                response = `${biter} bites ${bit}. Yikes!`;
+                break;
+        }
+
+        const embed: EmbedBuilder = new EmbedBuilder()
+            .setDescription(response)
+            .setColor(RED)
+            .setImage(gif);
+
+        await ctx.reply({
+            embeds: [embed]
+        });
+    },
+
+    // Error handler
+    error: defaultErrorHandler,
+
+    // Help command embed
+    help: new EmbedBuilder()
+        .setTitle("Bite")
+        .setDescription("A bite command for when you feel peckish")
+        .setFields(
+            { name: "Format", value: `\`/${name} <target>\`` },
+            { name: "target", value: "Required parameter. The user you want to bite" }
+        )
+};

--- a/src/commands/action/bite.ts
+++ b/src/commands/action/bite.ts
@@ -54,7 +54,7 @@ export const command: Command = {
         const tenor: TenorSingleton = TenorSingleton.getInstance();
         const biter: GuildMember = <GuildMember> ctx.member;
         const bit: GuildMember = <GuildMember> ctx.options.getMember("target") ?? null;
-        const gif: string = await tenor.getGifs("anime+bite");
+        const gif: string = await tenor.getGifs("bite");
 
         // If the user provided wasn't a member,
         // tell the user so

--- a/src/commands/action/bonk.ts
+++ b/src/commands/action/bonk.ts
@@ -54,7 +54,7 @@ export const command: Command = {
         const tenor: TenorSingleton = TenorSingleton.getInstance();
         const bonker: GuildMember = <GuildMember> ctx.member;
         const bonked: GuildMember = <GuildMember> ctx.options.getMember("target") ?? null;
-        const gif: string = await tenor.getGifs("anime+bonk");
+        const gif: string = await tenor.getGifs("bonk");
 
         // If the user provided wasn't a member,
         // tell the user so

--- a/src/commands/action/hug.ts
+++ b/src/commands/action/hug.ts
@@ -54,7 +54,7 @@ export const command: Command = {
         const tenor: TenorSingleton = TenorSingleton.getInstance();
         const hugger: GuildMember = <GuildMember> ctx.member;
         const hugged: GuildMember = <GuildMember> ctx.options.getMember("target") ?? null;
-        const gif: string = await tenor.getGifs("anime+hug");
+        const gif: string = await tenor.getGifs("hug");
 
         // If the user provided wasn't a member,
         // tell the user so

--- a/src/commands/action/kiss.ts
+++ b/src/commands/action/kiss.ts
@@ -54,7 +54,7 @@ export const command: Command = {
         const tenor: TenorSingleton = TenorSingleton.getInstance();
         const kisser: GuildMember = <GuildMember> ctx.member;
         const kissed: GuildMember = <GuildMember> ctx.options.getMember("target") ?? null;
-        const gif: string = await tenor.getGifs("anime+kiss");
+        const gif: string = await tenor.getGifs("kiss");
 
         // If the user provided wasn't a member,
         // tell the user so

--- a/src/commands/action/kiss.ts
+++ b/src/commands/action/kiss.ts
@@ -1,0 +1,106 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023-present Zahatikoff, Mirage Aegis
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import {
+    ChatInputCommandInteraction, EmbedBuilder, GuildMember, SlashCommandBuilder
+} from "discord.js";
+import { Command } from "../../util/command-template.js";
+import { defaultErrorHandler } from "../../util/error-handler.js";
+import { TenorSingleton } from "../../util/tenor-utils.js";
+import { PINK } from "../../util/colours.js";
+
+/*
+ * Creates an embed that states that the user had been kissed.
+ * The embed has an appropriate gif.
+ */
+
+const name: string = "kiss";
+
+export const command: Command = {
+    // Command headers
+    data: <SlashCommandBuilder> new SlashCommandBuilder()
+        .setName(name)
+        .setDescription("Show your love for someone by kissing them!")
+        .setDMPermission(false)
+        .addUserOption(o =>
+            o.setName("target")
+                .setDescription("The user you want to kiss")
+                .setRequired(true)
+        ),
+
+    // Command execution
+    async execute(ctx: ChatInputCommandInteraction): Promise<void> {
+        const tenor: TenorSingleton = TenorSingleton.getInstance();
+        const kisser: GuildMember = <GuildMember> ctx.member;
+        const kissed: GuildMember = <GuildMember> ctx.options.getMember("target") ?? null;
+        const gif: string = await tenor.getGifs("anime+kiss");
+
+        // If the user provided wasn't a member,
+        // tell the user so
+        if (!kissed) {
+            await ctx.reply("Couldn't find that member... who are you trying to kiss?");
+            return;
+        }
+
+        let response: string;
+
+        switch (true) {
+            case kisser.id === kissed.id:
+                // User tries to bonk themselves
+                response = "I don't think that's how it works.. but I'll help you out\n" +
+                           `${ctx.client.user} kisses ${kisser} on the forehead!`;
+                break;
+            case kissed.id === ctx.client.user.id:
+                // User tries to bonk Sushi Bot
+                response = "Oh, didn't really expect that\n" +
+                           `${kisser} kisses ${ctx.client.user}(?)`;
+                break;
+            default:
+                // User bonks someone else
+                response = `${kisser} kisses ${kissed}. How lovely!`;
+                break;
+        }
+
+        const embed: EmbedBuilder = new EmbedBuilder()
+            .setDescription(response)
+            .setColor(PINK)
+            .setImage(gif);
+
+        await ctx.reply({
+            embeds: [embed]
+        });
+    },
+
+    // Error handler
+    error: defaultErrorHandler,
+
+    // Help command embed
+    help: new EmbedBuilder()
+        .setTitle("Kiss")
+        .setDescription("A kiss command to show your love")
+        .setFields(
+            { name: "Format", value: `\`/${name} <target>\`` },
+            { name: "target", value: "Required parameter. The user you want to kiss" }
+        )
+};

--- a/src/commands/action/pat.ts
+++ b/src/commands/action/pat.ts
@@ -54,7 +54,7 @@ export const command: Command = {
         const tenor: TenorSingleton = TenorSingleton.getInstance();
         const patter: GuildMember = <GuildMember> ctx.member;
         const patted: GuildMember = <GuildMember> ctx.options.getMember("target") ?? null;
-        const gif: string = await tenor.getGifs("anime headpat");
+        const gif: string = await tenor.getGifs("headpat");
 
         // If the user provided wasn't a member,
         // tell the user so

--- a/src/commands/action/pat.ts
+++ b/src/commands/action/pat.ts
@@ -54,7 +54,7 @@ export const command: Command = {
         const tenor: TenorSingleton = TenorSingleton.getInstance();
         const patter: GuildMember = <GuildMember> ctx.member;
         const patted: GuildMember = <GuildMember> ctx.options.getMember("target") ?? null;
-        const gif: string = await tenor.getGifs("anime+headpat");
+        const gif: string = await tenor.getGifs("anime headpat");
 
         // If the user provided wasn't a member,
         // tell the user so

--- a/src/commands/action/roll.ts
+++ b/src/commands/action/roll.ts
@@ -71,11 +71,7 @@ export const command: Command = {
 
         const sides: number = ctx.options.getInteger("sides") ?? DEFAULT_SIDES;
         const amount: number = ctx.options.getInteger("amount") ?? MIN_AMOUNT;
-<<<<<<< HEAD
-        const multi: boolean = amount > 1;
-=======
         const multi: boolean = amount > MIN_AMOUNT;
->>>>>>> 17285a8e6caf1eff6c2cde302b387c916281ef16
         const user: User = ctx.user;
 
         // Roll a numbers between 1~sides

--- a/src/commands/action/roll.ts
+++ b/src/commands/action/roll.ts
@@ -1,0 +1,95 @@
+/* 
+ * MIT License
+ * 
+ * Copyright (c) 2023-present Mirage Aegis
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { SlashCommandBuilder, EmbedBuilder, ChatInputCommandInteraction, User } from "discord.js";
+import { Command } from "../../util/command-template.js";
+import { defaultErrorHandler } from "../../util/error-handler.js";
+
+/*
+ * A command for rolling a dice. The user can specify the amount of sides
+ * that the dice should have
+ */
+
+// The minimun amount of sides that a dice can have is 2
+const MIN_SIDES: number = 2;
+// The maximum amount of sides that a dice can have is 1000
+const MAX_SIDES: number = 1000;
+// The default dice has 6 sides
+const DEFAULT_SIDES: number = 6;
+// 1.5 seconds delay per roll
+const ROLL_DELAY: number = 1500;
+
+const name: string = "roll";
+
+export const command: Command = {
+    // Command headers
+    data: <SlashCommandBuilder> new SlashCommandBuilder()
+        .setName(name)
+        .setDescription("Roll a dice")
+        .setDMPermission(false)
+        .addIntegerOption(o =>
+            o.setName("sides")
+                .setDescription("The amount of sides the dice should have, defaults to 6")
+                .setMinValue(MIN_SIDES)
+                .setMaxValue(MAX_SIDES)
+        ),
+    
+    // Command exacution
+    async execute(ctx: ChatInputCommandInteraction): Promise<void> {
+        // Default values for parameters
+
+        const sides: number = ctx.options.getInteger("sides") ?? DEFAULT_SIDES;
+        const user: User = ctx.user;
+
+        // Roll a number between 1~sides
+        const roll: number = Math.ceil(Math.random() * sides);
+
+        // The
+        const response = await ctx.reply(`${user} rolls a D${sides}...\n`);
+
+        setTimeout(async () => {
+            await response.edit(
+                `${user} rolled ${roll} on a D${sides}!`
+            );
+        }, ROLL_DELAY);
+    },
+    
+    // Error handler
+    error: defaultErrorHandler,
+    
+    // Help command embed
+    help: new EmbedBuilder()
+        .setTitle("Roll")
+        .setDescription(
+            "A command for rolling a dice. You can specify the number of sides that the dice should have"
+        )
+        .addFields(
+            { name: "Format", value: `\`/${name} [sides]\`` },
+            {
+                name: "[sides]",
+                value: "Optional parameter. The amount of sides the dice should have, defaults to 6. " +
+                       "Accepts values between 2 and 1000"
+            }
+        )
+};

--- a/src/commands/action/roll.ts
+++ b/src/commands/action/roll.ts
@@ -37,6 +37,10 @@ const MIN_SIDES: number = 2;
 const MAX_SIDES: number = 1000;
 // The default dice has 6 sides
 const DEFAULT_SIDES: number = 6;
+// The minimum amount of dice to roll
+const MIN_AMOUNT: number = 1;
+// The maximum amount of dice to roll
+const MAX_AMOUNT: number = 10;
 // 1.5 seconds delay per roll
 const ROLL_DELAY: number = 1500;
 
@@ -46,13 +50,19 @@ export const command: Command = {
     // Command headers
     data: <SlashCommandBuilder> new SlashCommandBuilder()
         .setName(name)
-        .setDescription("Roll a dice")
+        .setDescription("Roll a die")
         .setDMPermission(false)
         .addIntegerOption(o =>
             o.setName("sides")
-                .setDescription("The amount of sides the dice should have, defaults to 6")
+                .setDescription("The amount of sides the die should have, defaults to 6")
                 .setMinValue(MIN_SIDES)
                 .setMaxValue(MAX_SIDES)
+        )
+        .addIntegerOption(o =>
+            o.setName("amount")
+                .setDescription("The amount of dice to throw, defaults to 1")
+                .setMinValue(MIN_AMOUNT)
+                .setMaxValue(MAX_AMOUNT)
         ),
     
     // Command exacution
@@ -60,15 +70,29 @@ export const command: Command = {
         // Default values for parameters
 
         const sides: number = ctx.options.getInteger("sides") ?? DEFAULT_SIDES;
+        const amount: number = ctx.options.getInteger("amount") ?? MIN_AMOUNT;
+        const multi: boolean = amount > MIN_AMOUNT;
         const user: User = ctx.user;
 
-        // Roll a number between 1~sides
-        const roll: number = Math.ceil(Math.random() * sides);
+        // Roll a numbers between 1~sides
+        let roll: number;
+        let multiResponse: string = `${user} rolled ${amount} D${sides}s, which resulted in the following:\n`;
+        for (let i = 0; i < amount; i++) {
+            roll = Math.ceil(Math.random() * sides);
+            multiResponse += `- ${Math.ceil(Math.random() * sides)}\n`;
+        }
 
-        // The
-        const response = await ctx.reply(`${user} rolls a D${sides}...\n`);
+        // The response saying that the dice is being rolled
+        const response = await ctx.reply(
+            `${user} rolls ${multi ? amount : "a"} D${sides}${multi ? "s" : ""}...\n`
+        );
 
         setTimeout(async () => {
+            if (multi) {
+                await response.edit(multiResponse);
+                return;
+            }
+
             await response.edit(
                 `${user} rolled ${roll} on a D${sides}!`
             );
@@ -85,11 +109,16 @@ export const command: Command = {
             "A command for rolling a dice. You can specify the number of sides that the dice should have"
         )
         .addFields(
-            { name: "Format", value: `\`/${name} [sides]\`` },
+            { name: "Format", value: `\`/${name} [sides] [amount]\`` },
             {
                 name: "[sides]",
-                value: "Optional parameter. The amount of sides the dice should have, defaults to 6. " +
+                value: "Optional parameter. The amount of sides the die should have, defaults to 6. " +
                        "Accepts values between 2 and 1000"
+            },
+            {
+                name: "[amount]",
+                value: "Optional parameter. The amount of dice to roll, defaults to 1. " +
+                       "Accepts values between 1 and 10"
             }
         )
 };

--- a/src/commands/action/roll.ts
+++ b/src/commands/action/roll.ts
@@ -37,6 +37,10 @@ const MIN_SIDES: number = 2;
 const MAX_SIDES: number = 1000;
 // The default dice has 6 sides
 const DEFAULT_SIDES: number = 6;
+// The minimum amount of dice to roll
+const MIN_AMOUNT: number = 1;
+// The maximum amount of dice to roll
+const MAX_AMOUNT: number = 10;
 // 1.5 seconds delay per roll
 const ROLL_DELAY: number = 1500;
 
@@ -46,13 +50,19 @@ export const command: Command = {
     // Command headers
     data: <SlashCommandBuilder> new SlashCommandBuilder()
         .setName(name)
-        .setDescription("Roll a dice")
+        .setDescription("Roll a die")
         .setDMPermission(false)
         .addIntegerOption(o =>
             o.setName("sides")
-                .setDescription("The amount of sides the dice should have, defaults to 6")
+                .setDescription("The amount of sides the die should have, defaults to 6")
                 .setMinValue(MIN_SIDES)
                 .setMaxValue(MAX_SIDES)
+        )
+        .addIntegerOption(o =>
+            o.setName("amount")
+                .setDescription("The amount of dice to throw, defaults to 1")
+                .setMinValue(MIN_AMOUNT)
+                .setMaxValue(MAX_AMOUNT)
         ),
     
     // Command exacution
@@ -60,15 +70,29 @@ export const command: Command = {
         // Default values for parameters
 
         const sides: number = ctx.options.getInteger("sides") ?? DEFAULT_SIDES;
+        const amount: number = ctx.options.getInteger("amount") ?? MIN_AMOUNT;
+        const multi: boolean = amount > 1;
         const user: User = ctx.user;
 
-        // Roll a number between 1~sides
-        const roll: number = Math.ceil(Math.random() * sides);
+        // Roll a numbers between 1~sides
+        let roll: number;
+        let multiResponse: string = `${user} rolled ${amount} D${sides}s, which resulted in the following:\n`;
+        for (let i = 0; i < amount; i++) {
+            roll = Math.ceil(Math.random() * sides);
+            multiResponse += `- ${Math.ceil(Math.random() * sides)}\n`;
+        }
 
-        // The
-        const response = await ctx.reply(`${user} rolls a D${sides}...\n`);
+        // The response saying that the dice is being rolled
+        const response = await ctx.reply(
+            `${user} rolls ${multi ? amount : "a"} D${sides}${multi ? "s" : ""}...\n`
+        );
 
         setTimeout(async () => {
+            if (multi) {
+                await response.edit(multiResponse);
+                return;
+            }
+
             await response.edit(
                 `${user} rolled ${roll} on a D${sides}!`
             );
@@ -85,11 +109,16 @@ export const command: Command = {
             "A command for rolling a dice. You can specify the number of sides that the dice should have"
         )
         .addFields(
-            { name: "Format", value: `\`/${name} [sides]\`` },
+            { name: "Format", value: `\`/${name} [sides] [amount]\`` },
             {
                 name: "[sides]",
-                value: "Optional parameter. The amount of sides the dice should have, defaults to 6. " +
+                value: "Optional parameter. The amount of sides the die should have, defaults to 6. " +
                        "Accepts values between 2 and 1000"
+            },
+            {
+                name: "[amount]",
+                value: "Optional parameter. The amount of dice to roll, defaults to 1. " +
+                       "Accepts values between 1 and 10"
             }
         )
 };

--- a/src/commands/configuration/config-subcommands/goodbye.ts
+++ b/src/commands/configuration/config-subcommands/goodbye.ts
@@ -85,7 +85,7 @@ export const command: Subcommand = {
     
     // Help command embed
     help: new EmbedBuilder()
-        .setTitle("Welcome")
+        .setTitle("Goodbye")
         .setDescription(
             "A server configutation command that sets the goodbye message for the server"
         )
@@ -97,7 +97,7 @@ export const command: Subcommand = {
                 value: "Optional parameter. The message to say goodbye with. Omit to use the default message\n" +
                        "Variables:\n" +
                        `- \`${NAME}\` - Replaced with the new member's display name\n` +
-                       `- \`${PING}\` - Replaced with a mention to the new member\n` +
+                       `- \`${PING}\` - Replaced with a mention to the member\n` +
                        `- \`${SERVER}\` - Replaced with the server's name\n` +
                        `- \`${OWNER}\` - Replaced with the server owner's display name\n` +
                        `- \`${NEW_LINE}\` - Replaced with a new line`

--- a/src/commands/configuration/config-subcommands/reactionroles.ts
+++ b/src/commands/configuration/config-subcommands/reactionroles.ts
@@ -337,7 +337,7 @@ export const command: Subcommand = {
             // Create a menu with the two message types
             const embedColourMenu: StringSelectMenuBuilder = new StringSelectMenuBuilder()
                 .setCustomId("colour")
-                .setPlaceholder("Select a reaction role message type")
+                .setPlaceholder("Select a colour for the embed")
                 .addOptions(
                     new StringSelectMenuOptionBuilder()
                         .setLabel("Red")

--- a/src/commands/configuration/config-subcommands/reactionroles.ts
+++ b/src/commands/configuration/config-subcommands/reactionroles.ts
@@ -857,6 +857,6 @@ export const command: Subcommand = {
             "A server configuration command that starts a reaction role setup wizard"
         )
         .addFields(
-            { name: "Format", value: `\`/${name}\`` }
+            { name: "Format", value: `\`/config ${name}\`` }
         )
 };

--- a/src/commands/configuration/config-subcommands/view.ts
+++ b/src/commands/configuration/config-subcommands/view.ts
@@ -1,0 +1,197 @@
+/* 
+ * MIT License
+ * 
+ * Copyright (c) 2023-present Mirage Aegis
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import {
+    SlashCommandSubcommandBuilder, EmbedBuilder, ChatInputCommandInteraction, Snowflake
+} from "discord.js";
+import { Subcommand } from "../../../util/command-template.js";
+import { defaultErrorHandler } from "../../../util/error-handler.js";
+import {
+    GoLive, Greeting, Logs, ReactionRoles, Server, Shoutout
+} from "../../../schemas/server";
+import { AZURE } from "../../../util/colours.js";
+import { NEW_LINE_RE } from "../../../events/shoutout.js";
+
+/*
+ * Displays server configurations.
+ * The data displayed by this command includes:
+ * - the logs channels;
+ * - the go-live channel and message;
+ * - the shout out channel, role, and message;
+ * - the number of reaction roles;
+ * - the welcome channel and message; and
+ * - the goodbye channel and message.
+ */
+
+const name: string = "view";
+
+export const command: Subcommand = {
+    // Command headers
+    data: new SlashCommandSubcommandBuilder()
+        .setName(name)
+        .setDescription("View the serber configurations for this server"),
+    
+    // Command exacution
+    async execute(ctx: ChatInputCommandInteraction): Promise<void> {
+        // The server configurations
+        const server: Server = await Server.get(ctx.guildId);
+
+        // The server configuration data
+        const logs: Logs = server.logs;
+        const goLive: GoLive = server.goLive;
+        const shoutout: Shoutout = server.shoutout;
+        const reactionRoles: ReadonlyMap<Snowflake, ReactionRoles> = server.reactionRoles;
+        const welcome: Greeting = server.welcome;
+        const goodbye: Greeting = server.goodbye;
+
+        // The base embed
+        const embed: EmbedBuilder = new EmbedBuilder()
+            .setTitle("Server configurations")
+            .setColor(AZURE)
+            .setDescription(
+                `These are the configurations for ${ctx.guild.name}`
+            )
+            .setAuthor({
+                name: ctx.guild.name,
+                iconURL: ctx.guild.iconURL()
+            });
+
+        // Fill in the configuration fields
+
+        // Add if any logs are configured
+        if (logs) {
+            embed.addFields(
+                {
+                    name: "Member logs",
+                    value: logs.members ? `<#${logs.members}>` : "null",
+                    inline: true
+                },
+                {
+                    name: "Message logs",
+                    value: logs.messages ? `<#${logs.messages}>` : "null",
+                    inline: true
+                },
+                {
+                    name: "Profile logs",
+                    value: logs.profiles ? `<#${logs.profiles}>` : "null",
+                    inline: true
+                }
+            );
+        }
+
+        // Add if automatic go-live posts are configured
+        if (goLive) {
+            embed.addFields(
+                {
+                    name: "Automatic go-live channel",
+                    value: `<#${goLive.channel}>`,
+                    inline: false
+                },
+                {
+                    name: "Automatic go-live message template",
+                    value: goLive.message?.replace(NEW_LINE_RE, "\n") ?? "default template",
+                    inline: false
+                }
+            );
+        }
+
+        // Add if automatic shout outs are configured
+        if (shoutout) {
+            embed.addFields(
+                {
+                    name: "Automatic shout out channel",
+                    value: `<#${shoutout.channel}>`,
+                    inline: false
+                },
+                {
+                    name: "Automatic shout out role",
+                    value: `<@&${shoutout.role}>`,
+                    inline: false
+                },
+                {
+                    name: "Automatic shout out message template",
+                    value: shoutout.message?.replace(NEW_LINE_RE, "\n") ?? "default template",
+                    inline: false
+                }
+            );
+        }
+
+        const reactionRoleCount: number = reactionRoles?.size;
+        // Add if reaction roles have been configured
+        if (reactionRoleCount) {
+            embed.addFields({
+                name: "Reaction role message count",
+                value: `${reactionRoleCount}`,
+                inline: false
+            });
+        }
+
+        // Add if automatic welcome posts are configured
+        if (welcome) {
+            embed.addFields(
+                {
+                    name: "Automatic welcome channel",
+                    value: `<#${welcome.channel}>`,
+                    inline: false
+                },
+                {
+                    name: "Automatic welcome message template",
+                    value: welcome.message?.replace(NEW_LINE_RE, "\n") ?? "default template",
+                    inline: false
+                }
+            );
+        }
+
+        // Add if automatic goodbye posts are configured
+        if (goodbye) {
+            embed.addFields(
+                {
+                    name: "Automatic goodbye channel",
+                    value: `<#${goodbye.channel}>`,
+                    inline: false
+                },
+                {
+                    name: "Automatic goodbye message template",
+                    value: goodbye.message?.replace(NEW_LINE_RE, "\n") ?? "default template",
+                    inline: false
+                }
+            );
+        }
+
+        await ctx.reply({ embeds: [embed] });
+    },
+    
+    // Error handler
+    error: defaultErrorHandler,
+    
+    // Help command embed
+    help: new EmbedBuilder()
+        .setTitle("View")
+        .setDescription(
+            "A server configuration command that displays the current configuration for a server"
+        )
+        .addFields(
+            { name: "Format", value: `\`/config ${name}\`` }
+        )
+};

--- a/src/commands/miscellaneous/serverstats.ts
+++ b/src/commands/miscellaneous/serverstats.ts
@@ -86,6 +86,11 @@ export const command: Command = {
             })
             .setFields(
                 {
+                    name: "Created",
+                    value: `<t:${ctx.guild.createdTimestamp}:f>`,
+                    inline: false
+                },
+                {
                     name: "Owner",
                     value: `${await ctx.guild.fetchOwner()}`,
                     inline: false

--- a/src/commands/miscellaneous/serverstats.ts
+++ b/src/commands/miscellaneous/serverstats.ts
@@ -36,6 +36,8 @@ import { AZURE } from "../../util/colours.js";
  * and bots in that server
  */
 
+const millisPerSecs: number = 1000;
+
 const name: string = "serverstats";
 
 export const command: Command = {
@@ -87,7 +89,7 @@ export const command: Command = {
             .setFields(
                 {
                     name: "Created",
-                    value: `<t:${ctx.guild.createdTimestamp}:f>`,
+                    value: `<t:${Math.floor(ctx.guild.createdTimestamp / millisPerSecs)}:f>`,
                     inline: false
                 },
                 {

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -384,7 +384,7 @@ export const onMessageEdit = async (client: Client, before: Message, after: Mess
     }
 
     try {
-        await logTo(client, server, Category.Profiles, embed);
+        await logTo(client, server, Category.Messages, embed);
     } catch (e) {
         await moderationLogsErrorHandler(
             MessageLogsAction.MessageEdit,
@@ -414,7 +414,7 @@ export const onMessageDelete = async (client: Client, message: Message): Promise
     }
 
     try {
-        await logTo(client, server, Category.Profiles, embed);
+        await logTo(client, server, Category.Messages, embed);
     } catch (e) {
         await moderationLogsErrorHandler(
             MessageLogsAction.MessageDelete,

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -36,6 +36,7 @@ import {
 import { Blacklist } from "../schemas/blacklist";
 import { formatGoLivePost, onCooldown, startCooldown } from "./shoutout";
 import { Action, formatGreeting } from "./greet";
+import { MemberLogsAction, MessageLogsAction, ProfileLogsAction, moderationLogsErrorHandler } from "../util/error-handler";
 
 /*
  * This module has event listeners for the bot
@@ -172,7 +173,16 @@ export const onMemberJoin = async (client: Client, member: GuildMember): Promise
     // The server and logs channel ID of the server that the member joined
     const server: Server = await Server.get(member.guild.id);
 
-    await logTo(client, server, Category.Members, genMemberJoinEmbed(member));
+    try {
+        await logTo(client, server, Category.Members, await genMemberJoinEmbed(member));
+    } catch (e) {
+        await moderationLogsErrorHandler(
+            MemberLogsAction.MemberJoin,
+            member.guild,
+            member.user,
+            e
+        );
+    }
 
     // Check if the new member is blacklisted
     const bl: Blacklist = await Blacklist.get();
@@ -206,7 +216,16 @@ export const onMemberLeave = async (client: Client, member: GuildMember): Promis
     // The server and logs channel ID of the server that the member left
     const server: Server = await Server.get(member.guild.id);
 
-    await logTo(client, server, Category.Members, await genMemberLeaveEmbed(member));
+    try {
+        await logTo(client, server, Category.Members, await genMemberLeaveEmbed(member));
+    } catch (e) {
+        await moderationLogsErrorHandler(
+            MemberLogsAction.MemberLeave,
+            member.guild,
+            member.user,
+            e
+        );
+    }
 
     await greet(client, member, server, Action.Goodbye);
 };
@@ -221,7 +240,16 @@ export const onMemberBan = async (client: Client, ban: GuildBan): Promise<void> 
     // The server and logs channel ID of the server that the member was banned from
     const server: Server = await Server.get(ban.guild.id);
 
-    await logTo(client, server, Category.Members, await genMemberBanEmbed(ban));
+    try {
+        await logTo(client, server, Category.Members, await genMemberBanEmbed(ban));
+    } catch (e) {
+        await moderationLogsErrorHandler(
+            MemberLogsAction.MemberBan,
+            ban.guild,
+            ban.user,
+            e
+        );
+    }
 };
 
 /**
@@ -234,7 +262,16 @@ export const onMemberUnban = async (client: Client, ban: GuildBan): Promise<void
     // The server and logs channel ID of the server that the member was unbanned from
     const server: Server = await Server.get(ban.guild.id);
 
-    await logTo(client, server, Category.Members, await genMemberUnbanEmbed(ban));
+    try {
+        await logTo(client, server, Category.Members, await genMemberUnbanEmbed(ban));
+    } catch (e) {
+        await moderationLogsErrorHandler(
+            MemberLogsAction.MemberUnban,
+            ban.guild,
+            ban.user,
+            e
+        );
+    }
 };
 
 // ----- !MEMBER RELATED -----
@@ -259,7 +296,18 @@ export const onMemberUpdate = async (client: Client, before: GuildMember, after:
         return;
     }
 
-    await logTo(client, server, Category.Profiles, embed);
+    try {
+        await logTo(client, server, Category.Profiles, embed);
+    } catch (e) {
+        await moderationLogsErrorHandler(
+            ProfileLogsAction.MemberUpdate,
+            before.guild,
+            before.user,
+            e,
+            before,
+            after
+        );
+    }
 };
 
 /**
@@ -298,7 +346,18 @@ export const onUserUpdate = async (client: Client, before: User, after: User): P
             iconURL: guild.iconURL()
         });
 
-        await logTo(client, server, Category.Profiles, embed);
+        try {
+            await logTo(client, server, Category.Profiles, embed);
+        } catch (e) {
+            await moderationLogsErrorHandler(
+                ProfileLogsAction.UserUpdate,
+                guild,
+                before,
+                e,
+                before,
+                after
+            );
+        }
     }
 };
 
@@ -324,7 +383,18 @@ export const onMessageEdit = async (client: Client, before: Message, after: Mess
         return;
     }
 
-    await logTo(client, server, Category.Messages, embed);
+    try {
+        await logTo(client, server, Category.Profiles, embed);
+    } catch (e) {
+        await moderationLogsErrorHandler(
+            MessageLogsAction.MessageEdit,
+            before.guild,
+            before.author,
+            e,
+            before,
+            after
+        );
+    }
 };
 
 /**
@@ -343,7 +413,17 @@ export const onMessageDelete = async (client: Client, message: Message): Promise
         return;
     }
 
-    await logTo(client, server, Category.Messages, embed);
+    try {
+        await logTo(client, server, Category.Profiles, embed);
+    } catch (e) {
+        await moderationLogsErrorHandler(
+            MessageLogsAction.MessageDelete,
+            message.guild,
+            message.author,
+            e,
+            message
+        );
+    }
 };
 
 // ----- MESSAGE RELATED -----

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -374,6 +374,11 @@ export const onUserUpdate = async (client: Client, before: User, after: User): P
  * @param after the message's current state
  */
 export const onMessageEdit = async (client: Client, before: Message, after: Message): Promise<void> => {
+    // Ignore own messages
+    if (before.author.id === client.user.id) {
+        return;
+    }
+    
     // The server and logs channel ID of the server that had a message edited
     const server: Server = await Server.get(before.guild.id);
     const embed: EmbedBuilder = genMessageEditEmbed(before, after);
@@ -404,6 +409,11 @@ export const onMessageEdit = async (client: Client, before: Message, after: Mess
  * @param message the message that was deleted
  */
 export const onMessageDelete = async (client: Client, message: Message): Promise<void> => {
+    // Ignore own messages
+    if (message.author.id === client.user.id) {
+        return;
+    }
+
     // The server and logs channel ID of the server that had a message deleted
     const server: Server = await Server.get(message.guild.id);
     const embed: EmbedBuilder = genMessageDeleteEmbed(message);

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -448,6 +448,13 @@ export const onPresenceUpdate = async (client: Client, before: Presence, after: 
     }
 
     const guild: Guild = after.guild;
+
+    // Force fetch members that aren't cached, to avoid partial data
+    // The joined timestamp is 0 for partial member objects
+    if (!guild.members.cache.get(before.userId).joinedTimestamp) {
+        await guild.members.fetch({ user: before.user, force: true });
+    }
+
     const server: Server = await Server.get(guild.id);
     const member: GuildMember = after.member;
     const uid: Snowflake = member.user.id;

--- a/src/events/logs.ts
+++ b/src/events/logs.ts
@@ -229,7 +229,7 @@ export const genMemberUpdateEmbed = (before: GuildMember, after: GuildMember): E
     if (oldNick !== newNick) {
         embed.addFields(
             { name: "Old nickname", value: oldNick ?? before.displayName, inline: false },
-            { name: "New nickname", value: newPfp ?? after.displayName, inline: false },
+            { name: "New nickname", value: newNick ?? after.displayName, inline: false },
         );
     }
 
@@ -255,8 +255,8 @@ export const genUserUpdateEmbed = (before: User, after: User): EmbedBuilder | nu
     // Properties to check
     const oldUsername: string = before.username;
     const newUsername: string = after.username;
-    const oldDisplayName: string = before.globalName;
-    const newDisplayName: string = after.globalName;
+    const oldDisplayName: string = before.displayName;
+    const newDisplayName: string = after.displayName;
     const oldPfp: string = before.avatar;
     const newPfp: string = after.avatar;
 

--- a/src/events/shoutout.ts
+++ b/src/events/shoutout.ts
@@ -70,7 +70,7 @@ const GAME_RE: RegExp = /{game}/g;
  * in the formatted string.
  */
 export const NEW_LINE: string = "{nl}";
-const NEW_LINE_RE: RegExp = /{nl}/g;
+export const NEW_LINE_RE: RegExp = /{nl}/g;
 
 /**
  * Default go-live and shout out string used when none is in the configurations.

--- a/src/schemas/server.ts
+++ b/src/schemas/server.ts
@@ -85,7 +85,7 @@ export type Logs = {
 export type Shoutout = {
     readonly channel?: Snowflake;
     readonly role?: Snowflake;
-    readonly message?: Snowflake;
+    readonly message?: string;
 };
 
 /**
@@ -96,7 +96,7 @@ export type Shoutout = {
  */
 export type GoLive = {
     readonly channel?: Snowflake;
-    readonly message?: Snowflake;
+    readonly message?: string;
 };
 
 /**
@@ -273,7 +273,9 @@ export class Server {
      * The Logs configuration
      */
     public get logs(): Logs {
-        return this.data.logs;
+        const logs: Logs = this.data.logs;
+        return logs.members || logs.messages || logs.profiles ?
+            logs : null;
     }
 
     public set logs(id: Snowflake) {

--- a/src/util/command-template.ts
+++ b/src/util/command-template.ts
@@ -38,7 +38,7 @@ export type Command = {
      * 
      * @param ctx the command context
      */
-    execute(ctx: ChatInputCommandInteraction): Promise<void>;
+    readonly execute: { (ctx: ChatInputCommandInteraction): Promise<void> };
 
 
     readonly error: ErrorHandler;
@@ -63,7 +63,7 @@ export type Subcommand = {
      * 
      * @param ctx the command context
      */
-    execute(ctx: ChatInputCommandInteraction): Promise<void>;
+    readonly execute: { (ctx: ChatInputCommandInteraction): Promise<void> };
 
 
     readonly error: ErrorHandler;

--- a/src/util/error-handler.ts
+++ b/src/util/error-handler.ts
@@ -23,7 +23,7 @@
  */
 
 import {
-    ButtonInteraction, ChatInputCommandInteraction, DiscordAPIError, Guild, GuildMember,
+    ButtonInteraction, ChatInputCommandInteraction, CommandInteractionOption, DiscordAPIError, Guild, GuildMember,
     Interaction, InteractionReplyOptions, Message, User
 } from "discord.js";
 import { NoMemberFoundError, UserIsMemberError } from "./errors";
@@ -87,12 +87,29 @@ export const defaultErrorHandler: ErrorHandler = async (ctx: ChatInputCommandInt
 
     const user: User = ctx.user;
 
+    let options: string = "{ ";
+    const optionsData: readonly CommandInteractionOption[] = ctx.options.data;
+
+    for (let i = 0; i < optionsData.length; i++) {
+        const option: CommandInteractionOption = optionsData[i];
+
+        // This line looks like a mess, so here's a breakdown:
+        // if the first option is being added, prepend with a new line,
+        // add the option in the following format: "name: type = value",
+        // Add a comma if it's not the last option, and
+        // add a new line
+        // eslint-disable-next-line no-magic-numbers
+        options += `${!i ? "\n" : ""}\t${option.name}: ${option.type} = ${option.value}${i === optionsData.length - 1 ? "," : ""}\n`;
+    }
+
+    options += "}";
+
     const report: string = "```\n" +
                            "Command Error\n\n" +
                            `Server: ${ctx.guild.name}\n` +
                            `User: ${user.id} (${user.username})\n` +
                            `Command: ${ctx.commandName}\n` +
-                           `Options: ${ctx.options.toString()}\n\n` +
+                           `Options: ${options}\n\n` +
                            // Error name, and error code if it's a Discord API error
                            `${err.name}${err instanceof DiscordAPIError ? `: ${err.code} (${err.message})` : ""}\n` +
                            "```";

--- a/src/util/init.ts
+++ b/src/util/init.ts
@@ -34,7 +34,6 @@ import {
     onMessageDelete, onMessageEdit, onPresenceUpdate, onServerJoin, onUserUpdate
 } from "../events/events";
 import { initRefreshReactionRolesInterval } from "../events/reactionroles";
-import { MemberLogsAction, MessageLogsAction, ProfileLogsAction, moderationLogsErrorHandler } from "./error-handler";
 
 /**
  * This module has an initialisation routine for the bot
@@ -93,114 +92,35 @@ export const loadListeners = (client: Client): void => {
     });
 
     client.on(Events.GuildMemberAdd, async (member: GuildMember): Promise<void> => {
-        try {
-            await onMemberJoin(client, member);
-        } catch (e) {
-            await moderationLogsErrorHandler(
-                MemberLogsAction.MemberJoin,
-                member.guild,
-                member.user,
-                e
-            );
-        }
+        await onMemberJoin(client, member);
     });
 
     client.on(Events.GuildMemberRemove, async (member: GuildMember): Promise<void> => {
-        try {
-            await onMemberLeave(client, member);
-        } catch (e) {
-            await moderationLogsErrorHandler(
-                MemberLogsAction.MemberLeave,
-                member.guild,
-                member.user,
-                e
-            );
-        }
+        await onMemberLeave(client, member);
     });
 
     client.on(Events.GuildBanAdd, async (ban: GuildBan): Promise<void> => {
-        try {
-            await onMemberBan(client, ban);
-        } catch (e) {
-            await moderationLogsErrorHandler(
-                MemberLogsAction.MemberBan,
-                ban.guild,
-                ban.user,
-                e
-            );
-        }
+        await onMemberBan(client, ban);
     });
 
     client.on(Events.GuildBanRemove, async (ban: GuildBan): Promise<void> => {
-        try {
-            await onMemberUnban(client, ban);
-        } catch (e) {
-            await moderationLogsErrorHandler(
-                MemberLogsAction.MemberBan,
-                ban.guild,
-                ban.user,
-                e
-            );
-        }
+        await onMemberUnban(client, ban);
     });
 
     client.on(Events.GuildMemberUpdate, async (before: GuildMember, after: GuildMember): Promise<void> => {
-        try {
-            await onMemberUpdate(client, before, after);
-        } catch (e) {
-            await moderationLogsErrorHandler(
-                ProfileLogsAction.MemberUpdate,
-                before.guild,
-                before.user,
-                e,
-                before,
-                after
-            );
-        }
+        await onMemberUpdate(client, before, after);
     });
 
     client.on(Events.UserUpdate, async (before: User, after: User): Promise<void> => {
-        try {
-            await onUserUpdate(client, before, after);
-        } catch (e) {
-            await moderationLogsErrorHandler(
-                ProfileLogsAction.UserUpdate,
-                null,
-                before,
-                e,
-                before,
-                after
-            );
-        }
+        await onUserUpdate(client, before, after);
     });
 
     client.on(Events.MessageUpdate, async (before: Message, after: Message): Promise<void> => {
-        try {
-            await onMessageEdit(client, before, after);
-        } catch (e) {
-            await moderationLogsErrorHandler(
-                MessageLogsAction.MessageEdit,
-                before.guild,
-                before.author,
-                e,
-                before,
-                after
-            );
-        }
+        await onMessageEdit(client, before, after);
     });
 
     client.on(Events.MessageDelete, async (message: Message): Promise<void> => {
-        try {
-            await onMessageDelete(client, message);
-        } catch (e) {
-            await moderationLogsErrorHandler(
-                MessageLogsAction.MessageDelete,
-                message.guild,
-                message.author,
-                e,
-                message
-            );
-        }
+        await onMessageDelete(client, message);
     });
 
     client.on(Events.Error, async (error: Error): Promise<void> => {

--- a/src/util/tenor-utils.ts
+++ b/src/util/tenor-utils.ts
@@ -31,7 +31,6 @@ import axios from "axios";
 import { TenorError } from "./errors";
 
 // Content safety filter level for the GIFs
-
 type FilterType = "off" | "low" | "medium" | "high";
 
 /*
@@ -130,7 +129,7 @@ type TenorMediaObject = {
 
 //
 
-const DEFAULT_RESPONSE_LIMIT: number = 50;
+const DEFAULT_RESPONSE_LIMIT: number = 20;
 const TWELVE_HOURS: number = 43_200_000;
 
 // Exported Singleton class that will later be used in the program.
@@ -186,7 +185,7 @@ export class TenorSingleton {
 
         /*eslint-disable camelcase*/
         const requestParams: TenorRequestParameters = {
-            q: topic,
+            q: "anime " + topic, // Prepend every query with "anime " to only receive anime gifs
             key: process.env.TENOR_API_KEY,
             client_key: "sushi-bot",
             contentfilter: "low",


### PR DESCRIPTION
# What Does This PR Do?
This PR adds more action commands for users to use, a command for server administrators to view their server configurations, and error logs for moderation log errors. Sushi Bot's version will be increased to 2.1.0 with this PR.

## Acceptance Criteria Met
- Sushi Bot has a command that displays server configurations to server administrators.
- Sushi Bot has a `/kiss` command that works similarly to `/bonk`.
- Sushi Bot has a `/bite` command that works similarly to `/bonk`.
- Sushi Bot has a `/roll` command that lets users roll 1\~10 dice with 2\~1000 sides.
- Moderation logs' try-catch blocks have been moved to the `logTo` calls.
- User update embeds should no longer error out because of empty strings.

## Related Issues
Closes #42 
Closes #43 
Closes #44 
