### PR TITLE
Anime Commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
                 "axios": "^1.4.0",
                 "discord.js": "^14.13.0",
                 "dotenv": "^16.0.3",
+                "kitsu": "^10.1.5",
+                "kitsu-core": "^10.1.5",
                 "mongoose": "^7.3.4"
             },
             "devDependencies": {
@@ -1475,6 +1477,43 @@
                 "node": ">=12.0.0"
             }
         },
+        "node_modules/kitsu": {
+            "version": "10.1.5",
+            "resolved": "https://registry.npmjs.org/kitsu/-/kitsu-10.1.5.tgz",
+            "integrity": "sha512-iN2Pe7FGSO8ZOrJ1udIv2RO0XfR6bMmTq1JQCNLAPyL6TdFV2aI15kttiXjoiG1bAo6abj/mbqiIioul21d61w==",
+            "dependencies": {
+                "axios": "^0.28.1",
+                "kitsu-core": "^10.1.5",
+                "pluralize": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/wopian"
+            }
+        },
+        "node_modules/kitsu-core": {
+            "version": "10.1.5",
+            "resolved": "https://registry.npmjs.org/kitsu-core/-/kitsu-core-10.1.5.tgz",
+            "integrity": "sha512-T9N9+a9+FA9TbSDuXz7tXPT0iEYEaGhokRtgihrg+GqU5++GbP+lElzfyKAl/qpU40mLKDaBnKcftjjSJFZarg==",
+            "engines": {
+                "node": ">= 14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/wopian"
+            }
+        },
+        "node_modules/kitsu/node_modules/axios": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.1.tgz",
+            "integrity": "sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==",
+            "dependencies": {
+                "follow-redirects": "^1.15.0",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
+            }
+        },
         "node_modules/levn": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -1903,6 +1942,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/pluralize": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+            "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
         "axios": "^1.4.0",
         "discord.js": "^14.13.0",
         "dotenv": "^16.0.3",
+        "kitsu": "^10.1.5",
+        "kitsu-core": "^10.1.5",
         "mongoose": "^7.3.4"
     },
     "devDependencies": {

--- a/src/commands/anime/anime-subcommands/get.ts
+++ b/src/commands/anime/anime-subcommands/get.ts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  * 
- * Copyright (c) 2023-present Mirage Aegis
+ * Copyright (c) 2024-present Fabian "Splitzy" Sales
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -53,7 +53,10 @@ export const command: Subcommand = {
     async execute(ctx: ChatInputCommandInteraction): Promise<void> {
         // Default values for parameters
         const query: string = ctx.options.getString("query");
-        let animeEmbed: EmbedBuilder = new EmbedBuilder().setTitle(`Anime Get \'${query}\'`).setColor("Orange").setThumbnail("https://avatars.slack-edge.com/2017-07-16/213464927747_f1d4f9fb141ef6666442_512.png")
+        let animeEmbed: EmbedBuilder = new EmbedBuilder()
+            .setTitle(`Anime Get \'${query}\'`)
+            .setColor("Orange")
+            .setThumbnail("https://avatars.slack-edge.com/2017-07-16/213464927747_f1d4f9fb141ef6666442_512.png")
         await ctx.deferReply();
 
         // Search for the anime
@@ -70,9 +73,9 @@ export const command: Subcommand = {
                         { name: "Type", value: anime.showType, inline: true },
                         { name: "Rating", value: anime.averageRating, inline: true },
                         { name: "Age Rating", value: anime.ageRating ? anime.ageRating : `${anime.ageRatingGuide}` || 'Not Yet Rated', inline: true },
-                        { name: "Start", value: anime.startDate, inline: true},
+                        { name: "Start", value: anime.startDate, inline: true },
                         { name: "End", value: anime.endDate || "ongoing", inline: true },
-                        { name: "  ", value: anime.youtubeVideoId ? `[Trailer](https://www.youtube.com/watch?v=${anime.youtubeVideoId})` : "No trailer available"}
+                        { name: "  ", value: anime.youtubeVideoId ? `[Trailer](https://www.youtube.com/watch?v=${anime.youtubeVideoId})` : "No trailer available" }
                     )
                     .setImage(anime.posterImage.large || anime.posterImage.original || anime.posterImage.medium || anime.posterImage.small || anime.posterImage.tiny)
             }

--- a/src/commands/anime/anime-subcommands/get.ts
+++ b/src/commands/anime/anime-subcommands/get.ts
@@ -1,0 +1,97 @@
+/*
+ * MIT License
+ * 
+ * Copyright (c) 2023-present Mirage Aegis
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import {
+    EmbedBuilder, ChatInputCommandInteraction, ChannelType, SlashCommandSubcommandBuilder, TextChannel
+} from "discord.js";
+import { Subcommand } from "../../../util/command-template.js";
+import { defaultErrorHandler } from "../../../util/error-handler.js";
+import Kitsu from "kitsu";
+
+const api = new Kitsu()
+
+/*
+ * A server command for searching for anime
+ */
+
+
+const name: string = "get";
+
+export const command: Subcommand = {
+    // Command headers
+    data: new SlashCommandSubcommandBuilder()
+        .setName(name)
+        .setDescription("search for an anime")
+        .addStringOption(o =>
+            o.setName("query")
+                .setDescription("The anime to search for")
+                .setRequired(true)
+        ),
+
+    // Command exacution
+    async execute(ctx: ChatInputCommandInteraction): Promise<void> {
+        // Default values for parameters
+        const query: string = ctx.options.getString("query");
+        let animeEmbed: EmbedBuilder = new EmbedBuilder().setTitle(`Anime Get \'${query}\'`).setColor("Orange").setThumbnail("https://avatars.slack-edge.com/2017-07-16/213464927747_f1d4f9fb141ef6666442_512.png")
+        await ctx.deferReply();
+
+        // Search for the anime
+        api.get('anime', { params: { filter: { text: query } } }).then((res: any) => {
+            if (res.data.length === 0) {
+                animeEmbed.setDescription("No results found");
+            } else {
+                const anime = res.data[0];
+                console.log(anime)
+                animeEmbed.setDescription(`${Object.values(anime.titles)[0]}`)
+                    .addFields(
+                        { name: "Status", value: anime.status },
+                        { name: "Episodes", value: anime.episodeCount.toString(), inline: true },
+                        { name: "Type", value: anime.showType, inline: true },
+                        { name: "Rating", value: anime.averageRating, inline: true },
+                        { name: "Age Rating", value: anime.ageRating ? anime.ageRating : `${anime.ageRatingGuide}` || 'Not Yet Rated', inline: true },
+                        { name: "Start", value: anime.startDate, inline: true},
+                        { name: "End", value: anime.endDate || "ongoing", inline: true },
+                        { name: "  ", value: anime.youtubeVideoId ? `[Trailer](https://www.youtube.com/watch?v=${anime.youtubeVideoId})` : "No trailer available"}
+                    )
+                    .setImage(anime.posterImage.large || anime.posterImage.original || anime.posterImage.medium || anime.posterImage.small || anime.posterImage.tiny)
+            }
+            ctx.followUp({ embeds: [animeEmbed] });
+        });
+
+    },
+
+    // Error handler
+    error: defaultErrorHandler,
+
+    // Help command embed
+    help: new EmbedBuilder()
+        .setTitle("Get")
+        .setDescription(
+            "A command for getting an anime's information"
+        )
+        .addFields(
+            { name: "Format", value: `\`/${name} [query]\`` },
+            { name: "[query]", value: "required parameter. The name of the anime you want to search for" }
+        )
+};

--- a/src/commands/anime/anime-subcommands/help.ts
+++ b/src/commands/anime/anime-subcommands/help.ts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-present Mirage Aegis
+ * Copyright (c) 2024-present Fabian "Splitzy" Sales
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/commands/anime/anime-subcommands/help.ts
+++ b/src/commands/anime/anime-subcommands/help.ts
@@ -1,0 +1,138 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023-present Mirage Aegis
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { SlashCommandSubcommandBuilder, EmbedBuilder, ChatInputCommandInteraction, Collection } from "discord.js";
+import { Subcommand } from "../../../util/command-template.js";
+import { defaultErrorHandler } from "../../../util/error-handler.js";
+import { MAGENTA } from "../../../util/colours.js";
+
+/*
+ * The help command for all anime commands
+ *
+ * This command module differs from all other commands because it needs to load them
+ * to access the help embed of each command
+ */
+
+// The default help window to show when no command is specified
+const defaultEmbed: EmbedBuilder = new EmbedBuilder()
+    .setTitle("Anime Help")
+    .setDescription("Here are all the anime commands! Use `/anime help <command>` to get help for a specific command")
+    .setColor(MAGENTA);
+
+
+// ----- LOAD HELP COMMAND EMBEDS -----
+
+const commands: Collection<string, EmbedBuilder> = new Collection();
+
+// The the contents of this folder
+const cmdFiles: string[] = fs.readdirSync(__dirname).filter(f => f.endsWith(".js"));
+
+// The string used to accumulate all commands
+let cmdstr: string = "";
+
+// Look through each JS file in each command in this folder
+for (const file of cmdFiles) {
+    // Skip this file
+    if (file === "help.js") {
+        cmdstr += "`/anime help`, ";
+        continue;
+    }
+
+    // Get the path of the current directory (/src) > "commands" > "configuration" > "config-subcommands" > command
+    const cmdPath: string = path.join(__dirname, file);
+    const cmd: Subcommand = require(cmdPath).command;
+    
+    // If the imported file is a valid command, add it
+    if ("data" in cmd && "execute" in cmd && "error" in cmd && "help" in cmd) {
+        const name: string = cmd.data.name;
+        // The colour is set to magenta here
+        commands.set(name, cmd.help.setColor(MAGENTA));
+        cmdstr += `\`/anime ${name}\`, `;
+    }
+}
+// Remove the dangling comma
+// eslint-disable-next-line no-magic-numbers
+cmdstr = cmdstr.slice(0, cmdstr.length - 2);
+
+defaultEmbed.addFields({ name: "Commands", value: cmdstr });
+
+const name: string = "help";
+
+// Help command embed
+const help: EmbedBuilder = new EmbedBuilder()
+    .setTitle("Help")
+    .setDescription("The help command which displays useful command information!")
+    .addFields(
+        { name: "Format", value: `\`/anime ${name} [command]\`` },
+        { name: "[command]", value: "Optional parameter. The command that you want to know more about" }
+    )
+    .setColor(MAGENTA);
+
+// Add the help field of the help command
+commands.set("help", help);
+
+// The command choices for the help command
+// with the required fields in each choice
+const choices = Array.from(commands.keys()).map((cmd: string): { name: string, value: string } => {
+    return { name: cmd, value: cmd };
+});
+
+export const command: Subcommand = {
+    // Command headers
+    data: new SlashCommandSubcommandBuilder()
+        .setName(name)
+        .setDescription("Need help with anime commands?")
+        .addStringOption(o =>
+            o.setName("command")
+                .setDescription("The command to get more information about")
+                .addChoices(...choices)
+        ),
+
+    // Command execution
+    async execute(ctx: ChatInputCommandInteraction): Promise<void> {
+        // Get the topic if it exists
+        const command = ctx.options.getString("command") ?? null;
+        
+        // If there is a topic, send its embed
+        if (command) {
+            // Set the embed author field to "Help" and add the server's icon
+            const embed = commands.get(command)
+                .setAuthor({ name: "Help", iconURL: ctx.guild.iconURL() });
+            await ctx.reply({ embeds: [embed] });
+            return;
+        } else { // Otherwise send the default help window
+            defaultEmbed.setAuthor({ name: "Help", iconURL: ctx.guild.iconURL() });
+            await ctx.reply({ embeds: [defaultEmbed] });
+            return;
+        }
+    },
+
+    // Error handler
+    error: defaultErrorHandler,
+
+    // Help command embed
+    help: help
+};

--- a/src/commands/anime/anime-subcommands/search.ts
+++ b/src/commands/anime/anime-subcommands/search.ts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  * 
- * Copyright (c) 2023-present Mirage Aegis
+ * Copyright (c) 2024-present Fabian "Splitzy" Sales
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/commands/anime/anime-subcommands/search.ts
+++ b/src/commands/anime/anime-subcommands/search.ts
@@ -1,0 +1,105 @@
+/*
+ * MIT License
+ * 
+ * Copyright (c) 2023-present Mirage Aegis
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import {
+    EmbedBuilder, ChatInputCommandInteraction, ChannelType, SlashCommandSubcommandBuilder, TextChannel
+} from "discord.js";
+import { Subcommand } from "../../../util/command-template.js";
+import { defaultErrorHandler } from "../../../util/error-handler.js";
+import Kitsu from "kitsu";
+
+const api = new Kitsu()
+
+/*
+ * A server command for searching for anime
+ */
+
+
+const name: string = "search";
+
+export const command: Subcommand = {
+    // Command headers
+    data: new SlashCommandSubcommandBuilder()
+        .setName(name)
+        .setDescription("search for an anime")
+        .addStringOption(o =>
+            o.setName("query")
+                .setDescription("The anime to search for")
+                .setRequired(true)
+        ),
+
+    // Command exacution
+    async execute(ctx: ChatInputCommandInteraction): Promise<void> {
+        // Default values for parameters
+        const query: string = ctx.options.getString("query");
+        let animeEmbed: EmbedBuilder = new EmbedBuilder().setTitle(`Kitsu Search: ${query}`).setColor("Orange").setThumbnail("https://avatars.slack-edge.com/2017-07-16/213464927747_f1d4f9fb141ef6666442_512.png")
+        await ctx.deferReply();
+
+        // Search for the anime
+        api.get('anime', { params: { filter: { text: query } } }).then((res: any) => {
+
+            const results = res.data.map((anime: any) => {
+                return {
+                    title: anime.titles,
+                    url: `https://kitsu.io/anime/${anime.id}`
+                }
+            });
+
+            console.log(results);
+
+            if (results.length === 0) {
+                animeEmbed.setDescription("No results found");
+            } else {
+
+                //parse out the titles
+                const titles = results.map((anime: any) => {
+                    return anime.title
+                }).map((title: any) => {
+                    const firstKey = Object.keys(title)[0];
+                    return title[firstKey];;
+                }).join('\n');
+
+                animeEmbed.setDescription("Here are the search results")
+                    .addFields({ name: "Anime", value: titles });
+
+            }
+            ctx.followUp({ embeds: [animeEmbed] })
+        });
+
+    },
+
+    // Error handler
+    error: defaultErrorHandler,
+
+    // Help command embed
+    help: new EmbedBuilder()
+        .setTitle("Search")
+        .setDescription(
+            "A command for searching for anime"
+        )
+        .addFields(
+            { name: "Format", value: `\`/${name} [query]\`` },
+            { name: "[query]", value: "required parameter. The name of the anime you want to search for" }
+        )
+};

--- a/src/commands/anime/anime.ts
+++ b/src/commands/anime/anime.ts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-present Mirage Aegis
+ * Copyright (c) 2024-present Fabian "Splitzy" Sales
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/commands/anime/anime.ts
+++ b/src/commands/anime/anime.ts
@@ -1,0 +1,90 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-present Mirage Aegis
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { SlashCommandBuilder, EmbedBuilder, ChatInputCommandInteraction, Collection, PermissionsBitField } from "discord.js";
+import { Command, Subcommand } from "../../util/command-template.js";
+
+/*
+ * The top level anime command
+ * 
+ * This command is a little different because it encompasses all anime
+ * commands in the form of subcommands
+ */
+
+const name: string = "anime";
+
+const data = new SlashCommandBuilder()
+    .setName(name)
+    .setDescription("A collection of anime commands")
+    .setDMPermission(false)
+
+const subcommands: Collection<string, Subcommand> = new Collection();
+
+const subcmdFolder: string = path.join(__dirname, "anime-subcommands");
+const subcmdFiles: string[] = fs.readdirSync(subcmdFolder).filter(f => f.endsWith(".js"));
+
+// Load all admin subcommands
+for (const file of subcmdFiles) {
+    const subcmdPath: string = path.join(subcmdFolder, file);
+    const subcmd: Subcommand = require(subcmdPath).command;
+
+    const name: string = subcmd.data.name;
+
+    subcommands.set(name, subcmd);
+    data.addSubcommand(subcmd.data);
+}
+
+export const command: Command = {
+    // Command headers
+    data: data,
+
+    // Command execution
+    async execute(ctx: ChatInputCommandInteraction): Promise<void> {
+        const subcmd = ctx.options.getSubcommand();
+
+        // Execute the requested subcommand
+        await subcommands.get(subcmd).execute(ctx);
+    },
+
+    // Error handler
+    async error(ctx: ChatInputCommandInteraction, err: Error): Promise<void> {
+        const subcmd = ctx.options.getSubcommand();
+
+        // Execute the requested subcommand's error handler
+        await subcommands.get(subcmd).error(ctx, err);
+    },
+
+    // Help command embed
+    help: new EmbedBuilder()
+        .setTitle("Anime")
+        .setDescription(
+            `Commands for Kitsu Anime API. Use \`/${name} help\` for information about these commands.`
+        )
+        .addFields(
+            { name: "Format", value: `\`/${name} <subcommand>\`` },
+            { name: "<subcommand>", value: "The subcommand to use" }
+        )
+};


### PR DESCRIPTION
# What Does This PR Do?

This PR adds `/anime` and sub-commands `get` and `search` using the Kitsu API to retrieve information on anime and anime searches.

## Acceptance Criteria Met
Which acceptance criteria will be met with this PR?
- Sushi bot now has an `anime search` command
- Sushi bot now has an `anime get` command